### PR TITLE
Fix SparkException: A master URL must be set in your configuration

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -235,7 +235,7 @@ import org.apache.spark.SparkConf
 object SimpleApp {
   def main(args: Array[String]) {
     val logFile = "YOUR_SPARK_HOME/README.md" // Should be some file on your system
-    val conf = new SparkConf().setAppName("Simple Application")
+    val conf = new SparkConf().setAppName("Simple Application").setMaster("local[2]")
     val sc = new SparkContext(conf)
     val logData = sc.textFile(logFile, 2).cache()
     val numAs = logData.filter(line => line.contains("a")).count()


### PR DESCRIPTION
Fix: Exception in thread "main" org.apache.spark.SparkException: A master URL must be set in your configuration
in standalone local mode without setting the master for example `.setMaster("local[2]")` getting this exception
see also other users same problem: http://stackoverflow.com/a/29177825/345859

Exception in thread "main" org.apache.spark.SparkException: A master URL must be set in your configuration
    at org.apache.spark.SparkContext.<init>(SparkContext.scala:206)
    at Example$.delayedEndpoint$Example$1(Example.scala:14)
    at Example$delayedInit$body.apply(Example.scala:10)
    at scala.Function0$class.apply$mcV$sp(Function0.scala:40)
    at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
    at scala.App$$anonfun$main$1.apply(App.scala:76)
    at scala.App$$anonfun$main$1.apply(App.scala:76)
    at scala.collection.immutable.List.foreach(List.scala:381)
    at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:35)
    at scala.App$class.main(App.scala:76)
    at Example$.main(Example.scala:10)
    at Example.main(Example.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:140)
